### PR TITLE
readme: use recommended go command for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the perfect toolkit to improve your slack emoji game.
 ## Installation
 
 ```
-go get -u github.com/oncilla/old-man-yells-at/cmd/old-man-yells-at
+go install github.com/oncilla/old-man-yells-at/cmd/old-man-yells-at@latest
 ```
 
 ## Usage


### PR DESCRIPTION
To install go binaries, `go get` has been replaced with `go install` in the meantime.